### PR TITLE
fft.h: include <cstring> for std::memcpy

### DIFF
--- a/fft.h
+++ b/fft.h
@@ -4,6 +4,7 @@
 #include <complex>
 #include <vector>
 #include <cmath>
+#include <cstring>
 
 #if defined(__FAST_MATH__) && (__apple_build_version__ >= 16000000) && (__apple_build_version__ <= 16000099) && !defined(SIGNALSMITH_IGNORE_BROKEN_APPLECLANG)
 #	error Apple Clang 16.0.0 generates incorrect SIMD for ARM. If you HAVE to use this version of Clang, turn off -ffast-math.


### PR DESCRIPTION
## Summary

`fft.h` uses `std::memcpy` inside `RealFFT<>::fft` and `RealFFT<>::ifft` (lines 1074 and 1284) without including `<cstring>`. On older libstdc++ this header was pulled in transitively through other standard headers, so the build succeeded by accident. Newer toolchains (GCC 13+, which ships with MSYS2 UCRT64) have reduced the transitive-include graph, and the build now fails with:

```
fft.h: In member function 'void signalsmith::linear::RealFFT<Sample, splitComputation, halfBinShift>::fft(size_t, const Sample*, Complex*)':
fft.h:1074:46: error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?
 1074 |             std::memcpy(tmpTime.data(), time, sizeof(Complex)*hSize);
fft.h: In member function 'void signalsmith::linear::RealFFT<Sample, splitComputation, halfBinShift>::ifft(size_t, const Complex*, Sample*)':
fft.h:1284:46: error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?
 1284 |             std::memcpy(time, tmpTime.data(), sizeof(Complex)*hSize);
```

This one-line change adds an explicit `#include <cstring>` so the header is self-contained and compiles on any conformant toolchain, without affecting platforms that previously compiled by accident.

Reproduced while building `signalsmith-stretch`'s C shim against MSYS2 UCRT64 (GCC 15.x):

```
g++ -O2 -std=c++17 -DNDEBUG -shared -static-libgcc -static-libstdc++ \
    -I.. -I. signalsmith_stretch_c.cpp -o signalsmith_stretch.dll
```

## Test plan

- [x] Rebuild the failing `signalsmith-stretch` command above under MSYS2 UCRT64 — compiles cleanly with the patch applied
- [ ] Reviewer: sanity-check on whatever CI the project uses (Linux/macOS/MSVC) to confirm no regression; the change is an additive `#include` so no behavior change is expected